### PR TITLE
Add news post: Jetstream2 + VGP genome assemblies

### DIFF
--- a/content/news/2026-02-24-jetstream2-vgp-genomes/index.md
+++ b/content/news/2026-02-24-jetstream2-vgp-genomes/index.md
@@ -1,0 +1,32 @@
+---
+title: "Jetstream2 + Galaxy = 518 VGP assemblies"
+date: "2026-02-24"
+tease: "IU-led Jetstream2 cloud computing and the Galaxy platform power the Vertebrate Genomes Project to produce 272 near error-free genome assemblies across 271 species."
+tags:
+- genome-assembly
+- vgp
+- jetstream2
+- cloud
+- research
+subsites: [all]
+contributions:
+  authorship:
+    - nekrut
+---
+
+![A phylogenetic tree showing the evolutionary relationships among 271 vertebrate species whose genomes were assembled by the Vertebrate Genomes Project](https://news.iu.edu/live/image/gid/13/width/1500/height/1500/crop/1/26608_Simplified_Figure_tree.rev.1768237318.webp)
+
+The [Vertebrate Genomes Project](https://vertebrategenomesproject.org/) (VGP), powered by Galaxy running on the IU-led [Jetstream2](https://jetstream-cloud.org/) cloud computing resource, has produced **272 near error-free genome assemblies** spanning **271 vertebrate species** and **518 haplotypes**. 
+
+## Galaxy and Jetstream2: A Powerful Partnership
+
+Producing genome assemblies at this scale and quality requires enormous computational resources. Galaxy, running on Indiana University's Jetstream2 cloud, provided the infrastructure to make it happen. Jetstream2's **large-memory nodes** (up to 1 TB of RAM) were critical for the memory-intensive steps of genome assembly, while its scalable cloud architecture allowed the VGP to process hundreds of genomes efficiently.
+
+Galaxy's accessible, web-based interface meant that researchers worldwide, including those without deep computational expertise, could participate in the assembly and analysis process. This combination of scalable cloud computing and an open, user-friendly platform was key to the project's success.
+
+> "These assemblies open the door to understanding the biology of species that have never had a reference genome. For non-model organisms, this changes everything."
+> — **Giulio Formenti**, Rockefeller University, VGP
+
+## Learn More
+
+Read the full story on IU News: [Jetstream2 helps map high-quality genomes for hundreds of vertebrate species](https://news.iu.edu/research/2026/02/13/jetstream2-dna-sequencing-vertebrate-genomes-project.html).


### PR DESCRIPTION
## Summary
- Adds a Galaxy Hub news post highlighting how Jetstream2 and Galaxy enabled the Vertebrate Genomes Project to produce 272 near error-free genome assemblies across 271 species
- References the IU News article from Feb 13, 2026

## Test plan
- [ ] Verify the post renders correctly on the Hub
- [ ] Confirm the external image URL loads properly
- [ ] Check frontmatter fields match Hub schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)